### PR TITLE
Implement glyph parsing and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# -k-system-ide# K-System IDE
+# K-System IDE
 
 **The K-System IDE** is a recursive symbolic development environment designed to execute real-time mathematics encoded in K-notation.
 
@@ -33,3 +33,12 @@ expr = 'Ω°Δ⦿'
 parsed = KParser().parse(expr)
 output = KRuntime().execute(parsed)
 print(output)
+```
+
+### Running tests
+
+Use Python's built-in test runner:
+
+```bash
+python -m unittest discover -s src/tests -v
+```

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -1,0 +1,11 @@
+"""Simple interpreter that resolves glyphs from a search path."""
+import os
+
+class Interpreter:
+    def __init__(self, search_path=None):
+        # Use the GLYPHS environment variable if provided
+        self.search_path = search_path or os.environ.get('GLYPHS', './glyphs')
+
+    def get_search_path(self):
+        """Return the active search path used for glyph resolution."""
+        return self.search_path

--- a/src/sim_engine.py
+++ b/src/sim_engine.py
@@ -1,5 +1,15 @@
 # Core simulation engine
 
+GLYPH_MAP = {
+    'Ω': 'OMEGA',
+    'Δ': 'DELTA',
+    '⦿': 'CIRCLE_WITH_DOT',
+}
+
 class SimEngine:
+    def parse_glyph(self, glyph):
+        """Return a simple name for the glyph or 'UNKNOWN'."""
+        return GLYPH_MAP.get(glyph, 'UNKNOWN')
+
     def simulate(self, input_signal):
         return f"Simulated output for: {input_signal}"

--- a/src/tests/test_parse_glyph.py
+++ b/src/tests/test_parse_glyph.py
@@ -1,0 +1,14 @@
+import unittest
+from src.sim_engine import SimEngine
+
+class TestParseGlyph(unittest.TestCase):
+    def test_known_glyph(self):
+        engine = SimEngine()
+        self.assertEqual(engine.parse_glyph('Ω'), 'OMEGA')
+
+    def test_unknown_glyph(self):
+        engine = SimEngine()
+        self.assertEqual(engine.parse_glyph('?'), 'UNKNOWN')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/test_sim.py
+++ b/src/tests/test_sim.py
@@ -1,7 +1,10 @@
-# Test for simulation engine
-
+import unittest
 from src.sim_engine import SimEngine
 
-sim = SimEngine()
-result = sim.simulate('⦿ΔΩ')
-print(result)
+class TestSimEngine(unittest.TestCase):
+    def test_simulate(self):
+        engine = SimEngine()
+        self.assertIn('⦿ΔΩ', engine.simulate('⦿ΔΩ'))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/temp.sh
+++ b/temp.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Temporary helper script
+
+echo "Temp script running"


### PR DESCRIPTION
## Summary
- add GLYPH_MAP and `parse_glyph` to simulation engine
- create an interpreter that checks the `GLYPHS` environment variable
- fix README heading and document running tests
- convert existing simulation test to `unittest` and add a new test for `parse_glyph`
- add executable helper script `temp.sh`

## Testing
- `python -m unittest discover -s src/tests -v`
